### PR TITLE
Remove manual CMAKE_OSX_ARCHITECTURES setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ if(HAVE_LSTAT)
 endif()
 
 check_function_exists(gethostuuid HAVE_GETHOSTUUID)
-if(HAVE_GETHOSTUUID AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
+if(HAVE_GETHOSTUUID AND NOT IOS)
     add_definitions(-DHAVE_GETHOSTUUID=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,11 +403,6 @@ if(WIN32)
     set(UUID_LIBRARIES Rpcrt4.lib)
 endif()
 
-if(APPLE)
-    # Universal bianry
-    set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
-endif()
-
 # Check the user defined sqlite config header file
 check_include_file(sqlite_cfg.h HAVE_SQLITE_CONFIG_H)
 if(HAVE_SQLITE_CONFIG_H)


### PR DESCRIPTION
This setting causes a compiler error when using toolchain files that sets it manually, like [ios-cmake](https://github.com/leetal/ios-cmake). Besides, its something that the user should decide.

I also changed how iOS is detected in the previous workaround that is merely a style change, should work the same :disguised_face: 